### PR TITLE
Add a simple dialog to DllConfig

### DIFF
--- a/src/plugin_front.c
+++ b/src/plugin_front.c
@@ -191,13 +191,34 @@ EXPORT void CALL DllAbout ( HWND hParent )
 	return;
 }
 
-#if 0
 EXPORT void CALL DllConfig ( HWND hParent )
 {
+	char tmpbuf[512];
+	int n_controllers;
+
+	if( !prepareHeap())
+		return;
+
+	pb_init(DebugMessage);
+	n_controllers = pb_scanControllers();
+
+	if (n_controllers <= 0) {
+		DebugMessage(M64MSG_ERROR, "No adapters detected.\n");
+		MessageBox( hParent, "raphnetraw: Adapter not detected.\n\nIf the adapter management tool is running,\nclose it.", "Warning", MB_OK | MB_ICONWARNING);
+		return;
+	}
+
 	DebugWriteA("CALLED: DllConfig\n");
+
+	snprintf(tmpbuf, sizeof(tmpbuf),
+					"No calibration or configuration required.\n"
+					"The controller will work, respond and feel exactly as it would in real life.\n\n"
+					"Controller ports detected: %d", n_controllers);
+
+	MessageBox( hParent, tmpbuf, "Raphnetraw Configuration", MB_OK | MB_ICONINFORMATION);
+
 	return;
 }
-#endif
 
 #if 0
 EXPORT void CALL DllTest ( HWND hParent )


### PR DESCRIPTION
On occasion, new raphnet adapter users are unsure if their adapter is working or think something is wrong because `Configure Controller Plugin...` is greyed out in Project64.

This attempts to solve that problem by adding a simple message box that informs them everything is ready, to make it less ambiguous. Wording was taken from [the product page](https://www.raphnet-tech.com/products/raphnetraw/index.php). Here is an example of what the dialog will look like:

![dialog](https://user-images.githubusercontent.com/1178816/119427050-56ca7a00-bcd8-11eb-940f-6a5e269205e2.png)

