### PR TITLE
Add special build with GetKeys support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,8 @@ PLUGIN_P1AND4=pj64raphnetraw_ports1and4.dll
 PLUGIN_P1AND3=pj64raphnetraw_ports1and3.dll
 PLUGIN_NET=pj64raphnetraw_net.dll
 PLUGIN_NET_MULTIPLAYER=pj64raphnetraw_net_multiplayer.dll
+PLUGIN_NOPAK=pj64raphnetraw_nopak.dll
+PLUGIN_NET_NOPAK=pj64raphnetraw_net_nopak.dll
 
 HIDAPI_BASE=../../hidapi
 HIDAPI_CFLAGS=-I$(HIDAPI_BASE)/hidapi
@@ -22,13 +24,15 @@ OBJS_P1AND3=$(patsubst %.o,objs_p1and3/%.o,$(OBJS))
 OBJS_1PLAYER=$(patsubst %.o,objs_1player/%.o,$(OBJS))
 OBJS_NET=$(patsubst %.o,objs_net/%.o,$(OBJS))
 OBJS_NET_MULTIPLAYER=$(patsubst %.o,objs_net_multiplayer/%.o,$(OBJS))
+OBJS_NOPAK=$(patsubst %.o,objs_nopak/%.o,$(OBJS))
+OBJS_NET_NOPAK=$(patsubst %.o,objs_net_nopak/%.o,$(OBJS))
 
 .PHONY: objdirs
 
-all: objdirs $(PLUGIN) $(PLUGIN_P1AND4) $(PLUGIN_P1AND3) $(PLUGIN_1PLAYER) $(PLUGIN_NET) $(PLUGIN_NET_MULTIPLAYER)
+all: objdirs $(PLUGIN) $(PLUGIN_P1AND4) $(PLUGIN_P1AND3) $(PLUGIN_1PLAYER) $(PLUGIN_NET) $(PLUGIN_NET_MULTIPLAYER) $(PLUGIN_NOPAK) $(PLUGIN_NET_NOPAK)
 
 objdirs:
-	mkdir -p objs objs_p1and4 objs_p1and3 objs_1player objs_net objs_net_multiplayer
+	mkdir -p objs objs_p1and4 objs_p1and3 objs_1player objs_net objs_net_multiplayer objs_nopak objs_net_nopak
 
 $(PLUGIN): $(OBJS_STD)
 	$(LD) -o $@ $^ $(LDFLAGS)
@@ -46,6 +50,12 @@ $(PLUGIN_NET): $(OBJS_NET)
 	$(LD) -o $@ $^ $(LDFLAGS)
 
 $(PLUGIN_NET_MULTIPLAYER): $(OBJS_NET_MULTIPLAYER)
+	$(LD) -o $@ $^ $(LDFLAGS)
+
+$(PLUGIN_NOPAK): $(OBJS_NOPAK)
+	$(LD) -o $@ $^ $(LDFLAGS)
+
+$(PLUGIN_NET_NOPAK): $(OBJS_NET_NOPAK)
 	$(LD) -o $@ $^ $(LDFLAGS)
 
 objs/%.o: %.c
@@ -66,7 +76,12 @@ objs_net/%.o: %.c
 objs_net_multiplayer/%.o: %.c
 	$(CC) $(CFLAGS) -c $^ -o $@ -DNO_BLOCK_IO
 
+objs_nopak/%.o: %.c
+	$(CC) $(CFLAGS) -c $^ -o $@ -DNO_PAK_SUPPORT
+
+objs_net_nopak/%.o: %.c
+	$(CC) $(CFLAGS) -c $^ -o $@ -DPORT_1_ONLY -DNO_BLOCK_IO -DNO_PAK_SUPPORT
 
 clean:
-	rm -vf $(PLUGIN) $(PLUGIN_P1AND4) $(PLUGIN_P1AND3) $(PLUGIN_1PLAYER) $(PLUGIN_NET) $(OBJS_STD) $(OBJS_P1AND4) $(OBJS_P1AND3) $(OBJS_1PLAYER) $(OBJS_NET) $(OBJS_NET_MULTIPLAYER) *.d
+	rm -vf $(PLUGIN) $(PLUGIN_P1AND4) $(PLUGIN_P1AND3) $(PLUGIN_1PLAYER) $(PLUGIN_NET) $(OBJS_STD) $(OBJS_P1AND4) $(OBJS_P1AND3) $(OBJS_1PLAYER) $(OBJS_NET) $(OBJS_NET_MULTIPLAYER) $(OBJS_NOPAK) $(OBJS_NET_NOPAK) *.d
 

--- a/src/plugin_back.c
+++ b/src/plugin_back.c
@@ -534,6 +534,7 @@ int pb_getKeys(int Control, BUTTONS *Keys)
 
 	if (res != 4) {
 		DebugMessage(PB_MSG_ERROR, "Unexpected data length\n");
+		Keys->Value = 0;
 		return 0;
 	}
 

--- a/src/plugin_back.h
+++ b/src/plugin_back.h
@@ -15,6 +15,7 @@ int pb_shutdown(void);
 int pb_scanControllers(void);
 int pb_readController(int Control, unsigned char *Command);
 int pb_controllerCommand(int Control, unsigned char *Command);
+int pb_getKeys(int Control, BUTTONS *Keys);
 int pb_romOpen(void);
 int pb_romClosed(void);
 


### PR DESCRIPTION
The stick accuracy of raphnet adapters is amazing and highly regarded among competitive Smash64 players. But the lack of `GetKeys()` support limits the community's options (and possibly others). A few netplay options exist for Smash64 players, but they are awkward at best (kaillera), and incompatible at worst ([AQZ](https://play64.com)) with `ReadController()`.

This patch adds support for a special build that sets raphnet controllers to `Controls[i].RawData = 0` and utilizes PJ64's `GetKeys()` function.

`pb_getKeys()` calls `gcn64lib_rawSiCommand()` and transforms the response into the proper `BUTTONS` struct. No other modifications are made, so the accuracy of `N64_GET_STATUS` calls should be the same as through `ReadController()`. This is basically the same as what [pollraw_n64()](https://github.com/raphnet/gcn64tools/blob/3ab094c1d3040666f65b2c79ef97e3f30d6a9094/src/pollraw.c#L23) does in [gcn64tools](https://github.com/raphnet/gcn64tools), if there's a more efficient way of doing this let me know!